### PR TITLE
Bug Docker compose build is failing

### DIFF
--- a/MicroserviceDemo/microservices/TenantManagementService.Host/Dockerfile
+++ b/MicroserviceDemo/microservices/TenantManagementService.Host/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR "/src/microservices/TenantManagementService.Host"
 RUN dotnet build "TenantManagementService.Host.csproj" -nowarn:msb3202,msb3277,nu1503 -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "TenantManagementService.Host.csproj"-nowarn:msb3202,msb3277,nu1503 -c Release -o /app/publish
+RUN dotnet publish "TenantManagementService.Host.csproj" -nowarn:msb3202,msb3277,nu1503 -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
microservices > TenantManagementService.Host > Dockerfile
need a empty space between project_name and options
info: issue occure in CMD & gitlab runner build
original line
RUN dotnet publish "TenantManagementService.Host.csproj"-nowarn:msb3202,msb3277,nu1503 -c Release -o /app/publish

update code
RUN dotnet publish "TenantManagementService.Host.csproj" -nowarn:msb3202,msb3277,nu1503 -c Release -o /app/publish


![image](https://user-images.githubusercontent.com/4032936/90957340-fe8eef00-e49d-11ea-8617-2fb0e31b4450.png)
