### PR TITLE
Fixes CI pipeline errors: The framework 'Microsoft.NETCore.App', version '5.0.12' (x64) was not found.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,12 +9,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@master
+    - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.101
-    - uses: actions/setup-dotnet@master
-      with:
-        dotnet-version: 6.0.100
+        dotnet-version: | 
+          5.0.x
+          6.0.x
 
     - name: Build All
       run: .\build-all.ps1

--- a/AcmeBookStoreAngularMaterial/aspnet-core/global.json
+++ b/AcmeBookStoreAngularMaterial/aspnet-core/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
- [Added roll-forward policy to use .NET SDK version 5.0.x](https://docs.microsoft.com/dotnet/core/tools/global-json#rollforward)
- [Simplify .NET SDK setup](https://github.com/actions/setup-dotnet)