### PR TITLE
add user/tenant args for #254

### DIFF
--- a/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/MyReportJob.cs
+++ b/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/MyReportJob.cs
@@ -1,14 +1,50 @@
 using Microsoft.Extensions.Logging;
+using System.Security.Claims;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Security.Claims;
+using Volo.Abp.Uow;
+using Volo.Abp.Users;
 
 namespace SeparateBackgroundJob.Common.Shared;
 
 public class MyReportJob : AsyncBackgroundJob<MyReportJobArgs>, ITransientDependency
 {
+    private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
+
+    public MyReportJob(ICurrentTenant currentTenant, ICurrentPrincipalAccessor currentPrincipalAccessor)
+    {
+        CurrentTenant = currentTenant;
+        _currentPrincipalAccessor = currentPrincipalAccessor;
+    }
+
+    private ICurrentTenant CurrentTenant { get; }
+
+    [UnitOfWork]
     public override Task ExecuteAsync(MyReportJobArgs args)
     {
         Logger.LogInformation("Executing MyReportJob with args: {0}", args.Content);
+
+        using (var scope = _currentPrincipalAccessor.Change(CreatePrincipal(args.UserId, args.TenantId)))
+        {
+            // Your code here, the user context has been changed.
+            Logger.LogInformation("Executing MyReportJob as tenant/user: {0}/{1}", args.TenantId, args.UserId);
+        }
+
         return Task.CompletedTask;
+    }
+
+    private ClaimsPrincipal CreatePrincipal(Guid userId, Guid? tenantId)
+    {
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new Claim(AbpClaimTypes.UserId, userId.ToString()));
+
+        if (tenantId.HasValue)
+        {
+            identity.AddClaim(new Claim(AbpClaimTypes.TenantId, tenantId.Value.ToString()));
+        }
+
+        return new ClaimsPrincipal(identity);
     }
 }

--- a/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/MyReportJobArgs.cs
+++ b/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/MyReportJobArgs.cs
@@ -3,4 +3,6 @@ namespace SeparateBackgroundJob.Common.Shared;
 public class MyReportJobArgs
 {
     public string? Content { get; set; }
+    public Guid UserId { get; set; }
+    public Guid? TenantId { get; set; }
 }

--- a/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/SeparateBackgroundJob.Common.Shared.csproj
+++ b/SeparateBackgroundJob/Shared/SeparateBackgroundJob.Common.Shared/SeparateBackgroundJob.Common.Shared.csproj
@@ -1,14 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>SeparateBackgroundJob.Common.Shared</RootNamespace>
+		<LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Volo.Abp.BackgroundJobs.Abstractions" Version="7.4.0-rc.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\SeparateBackgroundJob.Application.Contracts\SeparateBackgroundJob.Application.Contracts.csproj" />
+      <ProjectReference Include="..\..\src\SeparateBackgroundJob.Domain.Shared\SeparateBackgroundJob.Domain.Shared.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds user and tenant ids into the report job args and shows how they should be used. The sample doesn't contain any meaningful app service, but it would be nice to show how one is called within MyReportJob's execute as "authenticated"